### PR TITLE
Feat: UNT-T24130 Add action button to SSComposeInfoBar

### DIFF
--- a/app/src/main/java/com/simform/sscustominfobarapp/home/Home.kt
+++ b/app/src/main/java/com/simform/sscustominfobarapp/home/Home.kt
@@ -274,6 +274,19 @@ fun SSCustomInfoBarHome() {
                         )
                     }
                 }
+                CustomHomeButton(
+                    title = stringResource(R.string.show_composeinfobar_with_action),
+                    buttonType = ButtonType.ActionInfoBar
+                ) { btnType ->
+                    if (!composeInfoHostState.isVisible) {
+                        buttonType = btnType
+                        coroutineScope.showSSComposeInfoBar(
+                            context.getString(R.string.sscomposeinfobar_with_action).toTextType(),
+                            composeInfoHostState = composeInfoHostState,
+                            duration = duration
+                        )
+                    }
+                }
             }
         }
         AnimatedVisibility(visible = shouldShowSettingDialog) {

--- a/app/src/main/java/com/simform/sscustominfobarapp/utils/AppUtils.kt
+++ b/app/src/main/java/com/simform/sscustominfobarapp/utils/AppUtils.kt
@@ -1,10 +1,12 @@
 package com.simform.sscustominfobarapp.utils
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.simform.sscustominfobar.defaultInfoBars.ErrorInfoBar
 import com.simform.sscustominfobar.defaultInfoBars.SuccessInfoBar
@@ -36,6 +38,7 @@ enum class ButtonType {
     GradientDemoBrush,
     DrawableDemoSVG,
     DrawableDemoPNG,
+    ActionInfoBar
 }
 
 /**
@@ -128,7 +131,46 @@ fun InfoBarByButtonType(
             shape = shape,
             onClose = onClose
         )
+
+        ButtonType.ActionInfoBar -> DummyInfoBarWithAction(
+            title = content.title,
+            description = content.description,
+            isInfinite = isInfinite,
+            shape = shape,
+            onClose = onClose
+        )
     }
+}
+
+/**
+ * Dummy InfoBar to show [SSComposeInfoBar] with action.
+ *
+ * @param title Title string for the [SSComposeInfoBar].
+ * @param description Description string for the [SSComposeInfoBar].
+ * @param isInfinite Flag that decides whether [SSComposeInfoBar]'s duration is infinite.
+ * @param shape Shape of the [SSComposeInfoBar].
+ * @param onClose Called when user clicks on the clear button on the [SSComposeInfoBar].
+ */
+@Composable
+private fun DummyInfoBarWithAction(
+    title: TextType,
+    description: TextType? = null,
+    isInfinite: Boolean,
+    shape: Shape,
+    onClose: () -> Unit
+) {
+    val context = LocalContext.current
+    SSComposeInfoBar(
+        title = title,
+        description = description,
+        isInfinite = isInfinite,
+        shape = shape,
+        onCloseClicked = onClose,
+        onActionClicked = {
+            Toast.makeText(context, context.getString(R.string.action_clicked), Toast.LENGTH_SHORT)
+                .show()
+        }
+    )
 }
 
 /**
@@ -143,7 +185,7 @@ fun InfoBarByButtonType(
 @Composable
 private fun DummyDefaultInfoBar(
     title: TextType,
-    description: TextType,
+    description: TextType? = null,
     isInfinite: Boolean,
     shape: Shape,
     onClose: () -> Unit
@@ -171,7 +213,7 @@ private fun DummyDefaultInfoBar(
 @Composable
 private fun DummyInfoBarWithDrawableBackground(
     title: TextType,
-    description: TextType,
+    description: TextType? = null,
     background: Painter,
     isInfinite: Boolean,
     shape: Shape,
@@ -206,7 +248,7 @@ private fun DummyInfoBarWithDrawableBackground(
 @Composable
 private fun DummyInfobarWithSVGBackground(
     title: TextType,
-    description: TextType,
+    description: TextType? = null,
     background: Painter,
     isInfinite: Boolean,
     shape: Shape,
@@ -241,7 +283,7 @@ private fun DummyInfobarWithSVGBackground(
 @Composable
 private fun DummyGradientBrushDemo(
     title: TextType,
-    description: TextType,
+    description: TextType? = null,
     background: Brush,
     isInfinite: Boolean,
     shape: Shape,
@@ -277,7 +319,7 @@ private fun DummyGradientBrushDemo(
  */
 fun CoroutineScope.showSSComposeInfoBar(
     title: TextType,
-    description: TextType,
+    description: TextType? = null,
     composeInfoHostState: SSComposeInfoHostState,
     duration: SSComposeInfoDuration,
     context: CoroutineContext = EmptyCoroutineContext,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="drawable_demo_using_svg">Drawable Demo Using SVG</string>
     <string name="gradient_demo_using_brush">Gradient Demo using brush</string>
     <string name="drawable_demo_using_png">Drawable demo using PNG</string>
+    <string name="show_composeinfobar_with_action">Show ComposeInfoBar with action</string>
+    <string name="sscomposeinfobar_with_action">InfoBar with Action</string>
+    <string name="action_clicked">Action Clicked</string>
 </resources>

--- a/sscustominfobar/src/main/java/com/simform/sscustominfobar/main/SSComposeInfoBar.kt
+++ b/sscustominfobar/src/main/java/com/simform/sscustominfobar/main/SSComposeInfoBar.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +78,8 @@ data class SSComposeInfoBarColors(
  * @param contentColors The [SSComposeInfoBarColors] that represents the container and content color used in [SSComposeInfoBar].
  * @param contentPadding The [PaddingValues] that will be used to give padding to the contents of the [SSComposeInfoBar].
  * @param height The Height of the [SSComposeInfoBar].
+ * @param actionText The text of the Action in the [SSComposeInfoBar].
+ * @param onActionClicked Called when the user clicks the action button.
  * @param onCloseClicked Called when the user clicks the clear button on [SSComposeInfoBar].
  * @param isInfinite The flag that denotes whether the [SSComposeInfoBar]'s Display Duration is infinite or not, based on this flag the clear button will be shown and hidden.
  */
@@ -93,6 +97,8 @@ fun SSComposeInfoBar(
     contentColors: SSComposeInfoBarColors = SSComposeInfoBarDefaults.colors,
     contentPadding: PaddingValues = SSComposeInfoBarDefaults.contentPadding,
     height: Dp = SSComposeInfoBarDefaults.defaultHeight,
+    actionText: String = SSComposeInfoBarDefaults.defaultActionTitle,
+    onActionClicked: (() -> Unit)? = null,
     onCloseClicked: () -> Unit = {},
     isInfinite: Boolean = false
 ) {
@@ -168,6 +174,11 @@ fun SSComposeInfoBar(
                         overflow = TextOverflow.Ellipsis,
                         color = contentColors.descriptionColor
                     )
+                }
+            }
+            if (onActionClicked != null) {
+                ElevatedButton(onClick = onActionClicked) {
+                    Text(text = actionText)
                 }
             }
             if (isInfinite) {

--- a/sscustominfobar/src/main/java/com/simform/sscustominfobar/main/SSComposeInfoHost.kt
+++ b/sscustominfobar/src/main/java/com/simform/sscustominfobar/main/SSComposeInfoHost.kt
@@ -29,7 +29,7 @@ import com.simform.sscustominfobar.main.SSComposeInfoDuration.Long
 import com.simform.sscustominfobar.main.SSComposeInfoDuration.Short
 import com.simform.sscustominfobar.res.Dimens
 import com.simform.sscustominfobar.res.Dimens.DpEighty
-import com.simform.sscustominfobar.res.Dimens.DpLarge
+import com.simform.sscustominfobar.res.Dimens.DpMedium
 import com.simform.sscustominfobar.res.Dimens.DpSmall
 import com.simform.sscustominfobar.res.Dimens.DpTwelve
 import com.simform.sscustominfobar.res.Dimens.DpZero
@@ -54,7 +54,7 @@ private const val DESC_MAX_LINE = 2
  */
 data class SSComposeInfoBarData(
     val title: TextType,
-    val description: TextType
+    val description: TextType? = null
 )
 
 /**
@@ -203,8 +203,10 @@ object SSComposeInfoBarDefaults {
     /**
      * Default horizontalPadding and verticalPadding.
      */
-    private val ComposeInfoBarHorizontalPadding = DpLarge
+    private val ComposeInfoBarHorizontalPadding = DpMedium
     private val ComposeInfoBarVerticalPadding = DpSmall
+
+    val defaultActionTitle = "Action"
 
     /**
      * Default content padding for [SSComposeInfoBar].


### PR DESCRIPTION
Support for action and its callback in SSComposeInfoBar.
- Add action button in default SSComposeInfoBar to perform some action.
- Update padding in SSComposeInfoBar for better UI when action is also added to it.
- Made description of SSComposeInfoBar nullable so that the description can be an optional parameter.
