### PR TITLE
Feat: UNT-T24427 Add callback to SSComposeInfoHost when InfoBar gets dismissed.

### DIFF
--- a/app/src/main/java/com/simform/sscustominfobarapp/home/Home.kt
+++ b/app/src/main/java/com/simform/sscustominfobarapp/home/Home.kt
@@ -1,5 +1,6 @@
 package com.simform.sscustominfobarapp.home
 
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -112,6 +113,13 @@ fun SSCustomInfoBarHome() {
     }
     var direction by remember {
         mutableStateOf((SSComposeInfoBarDirection.Top))
+    }
+    composeInfoHostState.setOnInfoBarDismiss {
+        Toast.makeText(
+            context,
+            context.getString(R.string.info_bar_dismissed_successfully),
+            Toast.LENGTH_SHORT
+        ).show()
     }
     Box(modifier = Modifier.fillMaxSize()) {
         SSComposeInfoHost(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="show_composeinfobar_with_action">Show ComposeInfoBar with action</string>
     <string name="sscomposeinfobar_with_action">InfoBar with Action</string>
     <string name="action_clicked">Action Clicked</string>
+    <string name="info_bar_dismissed_successfully">Info Bar Dismissed Successfully!!</string>
 </resources>


### PR DESCRIPTION
Add callback to SSComposeInfoHost so user can perform some action after the info bar is successfully dismissed.